### PR TITLE
#14: Add bounds/extent coordinates for main arm and pitt river on channel bathymetry web map page

### DIFF
--- a/scripts/cbw_map_func.js
+++ b/scripts/cbw_map_func.js
@@ -33,11 +33,11 @@ const RiverSections = new Map([
     }],
     ["FRMA", {
         layers: ["combined", "conformance", "soundings"],
-        extents: new OpenLayers.Bounds(-13730138, 6282692,-13677350, 6314133)
+        extents: new OpenLayers.Bounds(-13692049.134674, 6277545.1912811, -13606133.914894, 6329522.3705077)
     }],
     ["PIRI", {
         layers: ["combined", "conformance", "soundings"],
-        extents: new OpenLayers.Bounds(-13730138, 6282692,-13677350, 6314133)
+        extents: new OpenLayers.Bounds(-13695106.615805, 6301928.6033007, -13609191.396025, 6353905.7825273)
     }],
 ]);
 


### PR DESCRIPTION
Closes #14. 

This PR adds map extents/coordinates for the Main and Pitt Rivers on the Channel Bathymetry Web map page. 

@wongrm I wasn't sure if we had a formal set of coordinates defined somewhere for the Main River and Pitt River (if we do please share -- couldn't find them in our current code base), so I manually retrieved the coordinates by focusing the map on the rivers and printing out the map extents. 

@cchou89 will review the pr 🙏 

**Recommended testing**: 
1. Visit the Channel Bathymetry Webmap (/avdpth_srch-eng.html?page=cbw)
2. Toggle the river selection to "Main Arm": 
![image](https://user-images.githubusercontent.com/22060917/147296230-953ee824-c531-4c46-af2b-9ef646a6402e.png)
3. Map should move to focus on the Main Arm river tiles. 
4. Repeat steps 2-3 with the Pitt River instead of the Main River